### PR TITLE
modified Upload.fixZip() to handle edge case of zip file has only 1 file

### DIFF
--- a/app/controllers/Upload.java
+++ b/app/controllers/Upload.java
@@ -235,9 +235,15 @@ public class Upload extends Controller {
         }
         if (r == null) return problemFiles;
         Map<Path, byte[]> fixedProblemFiles = new TreeMap<>();
-        for (Map.Entry<Path, byte[]> entry : problemFiles.entrySet()) {
-            fixedProblemFiles.put(r.relativize(entry.getKey()), entry.getValue());
+        if(problemFiles.keySet().size() == 1) {
+            fixedProblemFiles.put(r.getFileName(), problemFiles.get(r));
         }
+        else {
+            for (Map.Entry<Path, byte[]> entry : problemFiles.entrySet()) {
+                fixedProblemFiles.put(r.relativize(entry.getKey()), entry.getValue());
+            }
+        }
+
         return fixedProblemFiles;
     }
 


### PR DESCRIPTION
Since ``fixZip()`` relies on relative paths between multiple files within the zip file to function properly, it has minor problem handling the edge case when zip file contain only 1 single file. I modified fixZip() to handle that edge case. 