### PR TITLE
modify Util.prefix to handle localhost, Assignment.parseAssignment to work with locally hosted problems

### DIFF
--- a/app/controllers/Assignment.java
+++ b/app/controllers/Assignment.java
@@ -112,7 +112,13 @@ public class Assignment extends Controller {
                 String qid = null;
                 boolean checked = false;
                 if (problemDescriptor.startsWith("https")) problemURL = problemDescriptor;
-                else if (problemDescriptor.startsWith("http")) problemURL = "https" + problemDescriptor.substring(4);
+                else if (problemDescriptor.startsWith("http")) {
+                    problemURL = "https" + problemDescriptor.substring(4);
+                    // Check if the problem is local hosted or outside hosted, local hosted problem cannot use https
+                    if (!com.horstmann.codecheck.Util.exists(problemURL)) {
+                        problemURL = problemDescriptor;
+                    }                       
+                } 
                 else if (problemDescriptor.matches("[a-zA-Z0-9_]+(-[a-zA-Z0-9_]+)*")) { 
                     qid = problemDescriptor;
                     problemURL = "https://www.interactivities.ws/" + problemDescriptor + ".xhtml";

--- a/app/controllers/Assignment.java
+++ b/app/controllers/Assignment.java
@@ -113,12 +113,12 @@ public class Assignment extends Controller {
                 boolean checked = false;
                 if (problemDescriptor.startsWith("https")) problemURL = problemDescriptor;
                 else if (problemDescriptor.startsWith("http")) {
-                    problemURL = "https" + problemDescriptor.substring(4);
-                    // Check if the problem is local hosted or outside hosted, local hosted problem cannot use https
-                    if (!com.horstmann.codecheck.Util.exists(problemURL)) {
-                        problemURL = problemDescriptor;
-                    }                       
-                } 
+                    if (!problemDescriptor.startsWith("http://localhost") && !problemDescriptor.startsWith("http://127.0.0.1")) {
+                        problemURL = "https" + problemDescriptor.substring(4);
+                    }
+                    else
+                        problemURL = problemDescriptor;                    
+                }   
                 else if (problemDescriptor.matches("[a-zA-Z0-9_]+(-[a-zA-Z0-9_]+)*")) { 
                     qid = problemDescriptor;
                     problemURL = "https://www.interactivities.ws/" + problemDescriptor + ".xhtml";

--- a/app/controllers/Upload.java
+++ b/app/controllers/Upload.java
@@ -147,13 +147,7 @@ public class Upload extends Controller {
                 "<html><head><title></title><meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"/>");
         response.append("<body style=\"font-family: sans\">");
 
-        String prefix;
-        if(request.host().equals("localhost")) {
-            prefix = "../";
-        }
-        else {
-            prefix = (request.secure() ? "https://" : "http://") + request.host() + "/";
-        }
+        String prefix = models.Util.prefix(request) + "/";
 
         String problemUrl = prefix + type + "/" + problem;
         response.append("Public URL (for your students): ");

--- a/app/models/Util.java
+++ b/app/models/Util.java
@@ -20,7 +20,12 @@ public class Util {
          */   
         String prefix;
         if(request.host().equals("localhost")) {
-            prefix = "";
+            prefix = "../";
+            long countSlash = request.uri().chars().filter(ch -> ch == '/').count() - 1;
+            for (long i = 0; i < countSlash; ++i) {
+                prefix += "../";
+            }
+            prefix = prefix.substring(0, prefix.length() - 1);
         }
         else {
             prefix = (secure ? "https://" : "http://") + request.host();

--- a/app/models/Util.java
+++ b/app/models/Util.java
@@ -17,8 +17,15 @@ public class Util {
            and X-Forwarded-Proto has one ([https]). From 
            https://github.com/playframework/playframework/blob/814f0c73f86eb0e85bcae7f2167c73a08fed9fd7/transport/server/play-server/src/main/scala/play/core/server/common/ForwardedHeaderHandler.scala
            line 204, Play doesn't conclude that the connection was secure. 
-         */     
-        return (secure ? "https://" : "http://") + request.host();
+         */   
+        String prefix;
+        if(request.host().equals("localhost")) {
+            prefix = "";
+        }
+        else {
+            prefix = (secure ? "https://" : "http://") + request.host();
+        }  
+        return prefix;
     }
     
     public static ObjectNode toJson(Object obj) { 


### PR DESCRIPTION
I modified the Util.prefix with @cayhorstmann advice to handle localhost. 
I also modified Assignment.parseAssignment to work with locally hosted problems, the old method caused problem when parsing locally created problem when it replace problems' URL from HTTP to HTTPS.