### PR TITLE
change instructor feedback, not display feedback box on viewing own assignment

### DIFF
--- a/app/views/workAssignment.scala.html
+++ b/app/views/workAssignment.scala.html
@@ -24,7 +24,7 @@
         <dt>Private URL for you only:</dt><dd><span id="privateURL" class="ccurl"></span></dd>  
       </dl>     
       <p>ID: <span class="ccid"></span></p>
-      <label>Feedback:</label><br>
+      <label id="label_feedback_instruction">You can leave feedback for students when viewing their submissions</label><br>
       <textarea style="display: block; width: 80%; font-size: 14px; font-weight: 500;" id="comment" rows="10"></textarea>
       <div id='saveButtonDiv'></div>
    </div>

--- a/public/workAssignment.js
+++ b/public/workAssignment.js
@@ -313,15 +313,16 @@ window.addEventListener('DOMContentLoaded', () => {
     document.getElementById('student_lti_comment').textContent = "No Instructor's Feedback Yet"
   }
   
-  // Create button to save instructor's comment
-  if(!assignment.isStudent) {
+  // Create button to save instructor's comment when viewing student's submission
+  if(!assignment.isStudent && assignment.saveCommentURL) {
+    document.getElementById('label_feedback_instruction').textContent = 'Feedback'
     const submitButton = createButton('hc-command', 'Save Comment', async () => {
       let request = {
           assignmentID: assignment.assignmentID,
           workID: assignment.workID, // undefined when isStudent
           comment: document.getElementById('comment').value,
       }
-        
+      
       submitButton.disabled = true
       responseDiv.style.display = 'none'
       try {
@@ -344,5 +345,9 @@ window.addEventListener('DOMContentLoaded', () => {
       submitButton.disabled = false    
     })
     document.getElementById('saveButtonDiv').appendChild(submitButton) 
+  } 
+  else {
+    document.getElementById('comment').style.display = 'none'
   }
+
 })


### PR DESCRIPTION
The instructor's feedback textbox should only appear when instructor is viewing student's submission, not when instructor is viewing their own assignment for editing, cloning.