### PR TITLE
Added a feature to expand/collapse read-only files:

### DIFF
--- a/public/horstmann_codecheck.js
+++ b/public/horstmann_codecheck.js
@@ -821,8 +821,27 @@ window.addEventListener('load', async function () {
         filenameDiv.textContent = directoryPrefix + fileName
         fileObj.appendChild(filenameDiv)
         fileObj.appendChild(editorDiv)
-        setupAceEditor(editorDiv, editor, fileName, /*readonly*/ true)        
-        form.appendChild(fileObj)
+        setupAceEditor(editorDiv, editor, fileName, /*readonly*/ true)
+
+        let lines = editor.getSession().getDocument().getLength()
+
+        if (lines > 200) {
+          editor.setOption('maxLines', 200)
+          let viewButton = createButton('hc-start', _('Expand'), function() {
+            if (editor.getOption('maxLines') == lines) {
+                editor.setOption('maxLines', 200)
+                viewButton.innerHTML = _('Expand')
+            }
+            else {
+                editor.setOption('maxLines', lines)
+                viewButton.innerHTML = _('Collapse')
+            }
+          })
+          form.appendChild(fileObj)
+          form.appendChild(viewButton)
+        }
+        else
+          form.appendChild(fileObj)
       }  
       
 	  submitButton = createButton('hc-start', submitButtonLabel, async function() {


### PR DESCRIPTION
All read only files which exceed 200 lines will be collapsed down to show only 200 lines at a time and receive their own Expand button below file object. Clicking the Expand button will expand the file to show all the lines of text that the file has and change the button's name to Collapse. Clicking the Collapse button will collapse the file to show only 200 lines at a time.